### PR TITLE
Split locals for nat gateway ids

### DIFF
--- a/modules/subnets/locals.tf
+++ b/modules/subnets/locals.tf
@@ -7,5 +7,9 @@ locals {
   // then no routes to public internet are added.
   public_internet_mapping = { for x in var.private_subnets : x.name => replace(x.name, "-private-", "-public-") if var.nat_gateway_enabled == true }
 
-  subnet_ngw_ids = { for x in var.private_subnets : x.name => var.nat_gateway_enabled == true ? aws_nat_gateway.public[local.public_internet_mapping[x.name]].id : lookup(var.az_ngw_ids, x.availability_zone, null) }
+  subnet_ngw_ids_resource = { for x in var.private_subnets : x.name => var.nat_gateway_enabled == true ? aws_nat_gateway.public[local.public_internet_mapping[x.name]].id : null }
+
+  subnet_ngw_ids_custom = { for x in var.private_subnets : x.name => lookup(var.az_ngw_ids, x.availability_zone, null) }
+
+  subnet_ngw_ids = var.nat_gateway_enabled == true ? local.subnet_ngw_ids_resource : { for key,value in local.subnet_ngw_ids_custom : key => value if value != null }
 }

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -84,7 +84,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "default" {
-  for_each = { for x in var.private_subnets : x.name => local.subnet_ngw_ids[x.name] if local.subnet_ngw_ids[x.name] != null }
+  for_each = local.subnet_ngw_ids
 
   route_table_id         = aws_route_table.private[each.key].id
   nat_gateway_id         = each.value


### PR DESCRIPTION
## Description

The local for the nat gateway ids was causing issues when `custom_nat_gateway_enabled` was set to true. This was because terraform needs at least the key to be static for an argument to `for_each`, and in the case of nat gateways created by the module and the logic that was implemented, the key could only be determined after the apply. This PR is to fix that issue by splitting the local into 2 locals, so that not null condition can be applied on the nat gateway ids from vars, while maintaining the consistency with the nat gateways created within the module.

## Related Issue

- Closed issue : Follow up to PR on issue 70.

## Checklist

Please ensure that the following steps are completed before submitting the pull request:

- [x] Code follows the Terraform best practices and style guidelines.
- [x] Changes are appropriately documented, including any necessary updates to README or other documentation files.
- [ ] Unit tests have been added or updated to cover the changes introduced by this pull request.
- [x] Changes have been tested locally and verified to work as expected.
- [ ] The code has been reviewed to ensure it aligns with the project's goals and standards.
- [x] Dependencies and backward compatibility have been considered and addressed if applicable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

Run terraform apply on `examples/custom-subnets` while changing the values for the module attributes:

- `custom_nat_gateway_enabled` 
- `custom_az_ngw_ids`

Covering different scenarios.

